### PR TITLE
enforce limit based on number of account objects

### DIFF
--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -63,7 +63,7 @@ Handler const handlerArray[]{
     {"account_info", byRef(&doAccountInfo), Role::USER, NO_CONDITION},
     {"account_currencies",
      byRef(&doAccountCurrencies),
-     Role::USER,
+     Role::ADMIN,
      NO_CONDITION},
     {"account_lines", byRef(&doAccountLines), Role::USER, NO_CONDITION},
     {"account_channels", byRef(&doAccountChannels), Role::USER, NO_CONDITION},

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -143,19 +143,19 @@ getAccountObjects(
                 typeMatchesFilter(typeFilter.value(), sleNode->getType()))
             {
                 jvObjects.append(sleNode->getJson(JsonOptions::none));
+            }
 
-                if (++i == limit)
+            if (++i == limit)
+            {
+                if (++iter != entries.end())
                 {
-                    if (++iter != entries.end())
-                    {
-                        jvResult[jss::limit] = limit;
-                        jvResult[jss::marker] =
-                            to_string(dirIndex) + ',' + to_string(*iter);
-                        return true;
-                    }
-
-                    break;
+                    jvResult[jss::limit] = limit;
+                    jvResult[jss::marker] =
+                        to_string(dirIndex) + ',' + to_string(*iter);
+                    return true;
                 }
+
+                break;
             }
         }
 


### PR DESCRIPTION
Currently, the account_objects command limits based on number of
objects returned. This PR changes it to enforce limits based on
number of objects traversed.